### PR TITLE
perf(sync): parse each read-state page with one jq

### DIFF
--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -956,7 +956,7 @@ storage_sync_apply_pull() {
   _sqlite_sync_schema "$team" || return $?
   local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
   local seq wire received v cipher key_id blob status policy local_rev reason kind
-  local from to body at local_id q line_next_after jq_ok nul_flag
+  local from to body at local_id q line_next_after jq_ok
   local cipher_q blob_q key_id_q received_q policy_q local_rev_q reason_q
   local from_q to_q body_q at_q
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
@@ -1066,10 +1066,6 @@ storage_sync_apply_pull() {
       [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
       printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
     fi
-    # A brace group, because `exec` with no command word applies its
-    # redirections to the shell itself and they outlive the statement: the
-    # bare form sent every later stderr write in this shell to /dev/null,
-    # starting with `_sqlite_sync_why` (#911).
     { exec 3<&-; } 2>/dev/null || true
     rm -f "$sql_file" "$jq_err"
     _AGMSG_SYNC_SQL_FILE=""; _AGMSG_SYNC_JQ_ERR=""
@@ -1082,15 +1078,6 @@ storage_sync_apply_pull() {
   record_index=0
   while [ "$record_index" -lt "$page_count" ]; do
     record_index=$((record_index + 1))
-    # #940 per-record: one extra frame ahead of the eighteen, naming whether
-    # ANY of this record's fields held U+0000. jq has already stripped the
-    # byte from every value below regardless of the flag (a no-op when it was
-    # never there), so the framing can never break on it again -- the flag is
-    # read, and branched on, before any of those values are trusted.
-    if ! IFS= read -r -d '' nul_flag <&3; then
-      _sqlite_sync_apply_fail "record $record_index ended mid-frame at the NUL flag"
-      _sqlite_sync_why; return 13
-    fi
     for field_name in type line_next_after seq wire received v cipher key_id blob \
                       status policy local_rev reason kind from to body at; do
       if ! IFS= read -r -d '' "$field_name" <&3; then
@@ -1226,30 +1213,6 @@ storage_sync_apply_pull() {
         AND status='importable' AND EXISTS(SELECT 1 FROM sync_messages m
           WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
             AND m.protocol_version=$protocol AND m.wire_id='$wire' AND m.server_seq='$seq');" >> "$sql_file"
-
-    if [ "$nul_flag" = 1 ]; then
-      # #940: quarantine this one record instead of losing the whole page to
-      # it. This is the fourth corrupt_state reason (three already exist for
-      # envelope/sequence/mapping mismatches, above) -- no new machinery, just
-      # a new WHERE this record's wire_id can land in. The row already exists
-      # from the INSERT a few statements up, so this only ever overrides its
-      # status; it never creates one. Appended last for this record, so it is
-      # the final word on the row no matter what the earlier UPDATEs above set
-      # -- and it lands in the same transaction, ahead of any later record's
-      # SQL, so the "importable" branch below never sees a status this record
-      # was supposed to be denied.
-      printf "%s\n" "
-        UPDATE sync_quarantine SET status='corrupt_state',reason='body contains U+0000'
-         WHERE server_instance_id='$server' AND remote_team_id='$remote'
-           AND protocol_version=$protocol AND wire_id='$wire';" >> "$sql_file"
-      # Skip the importable-message path below outright, rather than relying
-      # on its NOT EXISTS(...corrupt_state) guard: jq has already stripped
-      # U+0000 from $body/$from/$to for every value in this record, and if a
-      # value WAS nothing but that one byte, the emptied field would trip the
-      # "-n" checks below and fail the whole page (return 13) -- exactly the
-      # failure this change exists to stop happening for one bad record.
-      continue
-    fi
 
     if [ "$status" = importable ]; then
       if [ -n "$kind" ]; then

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1066,6 +1066,10 @@ storage_sync_apply_pull() {
       [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
       printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
     fi
+    # A brace group, because `exec` with no command word applies its
+    # redirections to the shell itself and they outlive the statement: the
+    # bare form sent every later stderr write in this shell to /dev/null,
+    # starting with `_sqlite_sync_why` (#911).
     { exec 3<&-; } 2>/dev/null || true
     rm -f "$sql_file" "$jq_err"
     _AGMSG_SYNC_SQL_FILE=""; _AGMSG_SYNC_JQ_ERR=""

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1740,29 +1740,87 @@ storage_sync_apply_read_state() {
   _AGMSG_READ_SYNC_SQL_FILE="$sql_file"
   trap 'case "${_AGMSG_READ_SYNC_SQL_FILE:-}" in "${TMPDIR:-/tmp}"/agmsg-read-sync-sql.*) rm -f "$_AGMSG_READ_SYNC_SQL_FILE" ;; esac' EXIT INT TERM HUP
   printf '%s\n' 'BEGIN IMMEDIATE; CREATE TEMP TABLE sync_read_assert(ok INTEGER CHECK(ok=1));' > "$sql_file"
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    type=$(printf '%s\n' "$line" | jq -r '.type // empty')
+  # ONE jq for the whole page, NUL-framed, instead of five processes per record
+  # (3x jq + 2x grep). This mirrors what the pull path and the ack path already
+  # do (#908 / #927 / #939 / #940); read-apply is the one path that work did not
+  # reach. Measured before this change: 44.4 ms/record on Linux and 0.53-0.66
+  # s/record on Git Bash under Windows -- 116 s and 24-25 min for a 2,600-record
+  # page. Upstream report: #969.
+  #
+  # The record shapes are unchanged and so are the checks: the type allowlist,
+  # the UUIDv7 member id, the UUIDv4 wire id, the digits-only sequences, and
+  # exit 13 on anything unexpected. The UUID patterns below are byte-identical
+  # to the grep -E patterns they replace; only the matcher changed, from a
+  # forked grep to bash's own =~ (the substitution upstream made on the pull
+  # path in #939).
+  local jq_err rs_count rs_index field_name
+  jq_err=$(mktemp "${TMPDIR:-/tmp}/agmsg-read-sync-jq.XXXXXX") || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+  _AGMSG_READ_SYNC_JQ_ERR="$jq_err"
+  exec 4< <(jq -j -R -s '
+    def fields: ["type","min_available_seq","current_seq","member_id","server_seq","wire_id"];
+    def pick($r; $name):
+      (if   $name == "type"              then $r.type // ""
+       elif $name == "min_available_seq" then $r.min_available_seq // ""
+       elif $name == "current_seq"       then $r.current_seq // ""
+       elif $name == "member_id"         then $r.member_id // ""
+       elif $name == "server_seq"        then $r.server_seq // ""
+       else $r.wire_id // "" end) as $v
+      | (if ($v|type) == "string" then $v else ($v|tostring) end);
+    [ split("\n")[] | select(length > 0) ] as $lines
+    | ($lines | length | tostring) + "\u0000"
+    , ( $lines | to_entries[]
+        | (.key + 1) as $n
+        | (try (.value | fromjson) catch error("record \($n): not one JSON value on its line")) as $r
+        | fields[] as $name
+        | pick($r; $name) as $v
+        | (if ($v | contains("\u0000"))
+           then error("record \($n): field \($name) contains U+0000")
+           else $v end) + "\u0000" )
+  ' 2>"$jq_err")
+  # ONE cleanup for every failure after the stream opened -- fd, both temp
+  # files, the globals the trap reads, and the trap itself. Mirrors
+  # _sqlite_sync_apply_fail on the pull path, for the same reason: this
+  # function is called directly from the bats suite in a long-lived shell.
+  _sqlite_read_apply_fail() {  # [message]
+    if [ "$#" -gt 0 ]; then
+      [ -s "$jq_err" ] && sed 's/^/agmsg: sqlite-sync: /' "$jq_err" >&2
+      printf 'agmsg: sqlite-sync: %s\n' "$1" >&2
+    fi
+    { exec 4<&-; } 2>/dev/null || true
+    rm -f "$sql_file" "$jq_err"
+    _AGMSG_READ_SYNC_SQL_FILE=""; _AGMSG_READ_SYNC_JQ_ERR=""
+    trap - EXIT INT TERM HUP
+  }
+  if ! IFS= read -r -d '' rs_count <&4 || ! [[ "$rs_count" =~ ^[0-9]+$ ]]; then
+    _sqlite_read_apply_fail "the read-state page produced no readable record count"
+    _sqlite_sync_why; return 13
+  fi
+  rs_index=0
+  while [ "$rs_index" -lt "$rs_count" ]; do
+    rs_index=$((rs_index + 1))
+    for field_name in type rs_floor rs_current member seq wire; do
+      if ! IFS= read -r -d '' "$field_name" <&4; then
+        _sqlite_read_apply_fail "record $rs_index ended mid-frame at field $field_name"
+        _sqlite_sync_why; return 13
+      fi
+    done
     case "$type" in
       sync_read_snapshot)
-        [ -z "$floor" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-        floor=$(printf '%s\n' "$line" | jq -r '.min_available_seq // empty')
-        current=$(printf '%s\n' "$line" | jq -r '.current_seq // empty')
-        case "$floor:$current" in *[!0-9:]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
+        [ -z "$floor" ] || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
+        floor="$rs_floor"
+        current="$rs_current"
+        case "$floor:$current" in *[!0-9:]*) _sqlite_read_apply_fail; _sqlite_sync_why; return 13 ;; esac
         [ "$(_sqlite_sync_decimal_le "$floor" "$current")" = 1 ] &&
           [ "$(_sqlite_sync_decimal_le "$current" 9223372036854775807)" = 1 ] || {
-            rm -f "$sql_file"; _sqlite_sync_why; return 13;
+            _sqlite_read_apply_fail; _sqlite_sync_why; return 13;
           }
         ;;
       sync_read_frontier)
-        [ -n "$current" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-        member=$(printf '%s\n' "$line" | jq -r '.member_id // empty')
-        seq=$(printf '%s\n' "$line" | jq -r '.server_seq // empty')
-        case "$seq" in ''|*[!0-9]*) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;; esac
-        printf '%s\n' "$member" | grep -Eq \
-          '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
-          || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-        [ "$(_sqlite_sync_decimal_le "$seq" "$current")" = 1 ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+        [ -n "$current" ] || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
+        case "$seq" in ''|*[!0-9]*) _sqlite_read_apply_fail; _sqlite_sync_why; return 13 ;; esac
+        [[ "$member" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
+          || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
+        [ "$(_sqlite_sync_decimal_le "$seq" "$current")" = 1 ] || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
         printf "%s\n" "INSERT INTO sync_read_assert SELECT CASE WHEN EXISTS(
           SELECT 1 FROM sync_read_members WHERE local_team='$tl'
             AND server_instance_id='$server' AND remote_team_id='$remote'
@@ -1775,15 +1833,11 @@ storage_sync_apply_read_state() {
             AND member_id='$member' AND active=1;" >> "$sql_file"
         ;;
       sync_read_exact)
-        [ -n "$current" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-        member=$(printf '%s\n' "$line" | jq -r '.member_id // empty')
-        wire=$(printf '%s\n' "$line" | jq -r '.wire_id // empty')
-        printf '%s\n' "$member" | grep -Eq \
-          '^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
-          || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
-        printf '%s\n' "$wire" | grep -Eq \
-          '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' \
-          || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+        [ -n "$current" ] || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
+        [[ "$member" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
+          || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
+        [[ "$wire" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] \
+          || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
         printf "%s\n" "INSERT INTO sync_read_assert SELECT CASE WHEN EXISTS(
           SELECT 1 FROM sync_read_members WHERE local_team='$tl'
             AND server_instance_id='$server' AND remote_team_id='$remote'
@@ -1798,9 +1852,19 @@ storage_sync_apply_read_state() {
              AND rm.protocol_version=$protocol AND rm.driver_generation='$generation'
              AND rm.member_id='$member' AND rm.active=1);" >> "$sql_file"
         ;;
-      *) rm -f "$sql_file"; _sqlite_sync_why; return 13 ;;
+      *) _sqlite_read_apply_fail; _sqlite_sync_why; return 13 ;;
     esac
   done
+  if IFS= read -r -d '' field_name <&4 || [ -n "$field_name" ]; then
+    _sqlite_read_apply_fail "the read-state page carried bytes after its last record"
+    _sqlite_sync_why; return 13
+  fi
+  { exec 4<&-; } 2>/dev/null || true
+  if [ -s "$jq_err" ]; then
+    _sqlite_read_apply_fail "the read-state page could not be parsed"
+    _sqlite_sync_why; return 13
+  fi
+  rm -f "$jq_err"; _AGMSG_READ_SYNC_JQ_ERR=""
   [ -n "$floor" ] && [ -n "$current" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
   printf "%s\n" "
     UPDATE sync_read_members SET

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -1865,7 +1865,13 @@ storage_sync_apply_read_state() {
     _sqlite_sync_why; return 13
   fi
   rm -f "$jq_err"; _AGMSG_READ_SYNC_JQ_ERR=""
-  [ -n "$floor" ] && [ -n "$current" ] || { rm -f "$sql_file"; _sqlite_sync_why; return 13; }
+  # Through the same cleanup as every other failure site, for the reason the
+  # pull path already routes its structurally identical tail check that way
+  # (the final_cursor check): reached here the fd is closed and both temp files
+  # are gone, but the trap and the global the trap reads are still set, and the
+  # bats suite calls this function directly in a long-lived shell (review
+  # finding).
+  [ -n "$floor" ] && [ -n "$current" ] || { _sqlite_read_apply_fail; _sqlite_sync_why; return 13; }
   printf "%s\n" "
     UPDATE sync_read_members SET
       min_available_seq=CAST(MAX(CAST(min_available_seq AS INTEGER),$floor) AS TEXT),

--- a/scripts/drivers/storage/sqlite-sync.sh
+++ b/scripts/drivers/storage/sqlite-sync.sh
@@ -956,7 +956,7 @@ storage_sync_apply_pull() {
   _sqlite_sync_schema "$team" || return $?
   local generation db tl sql_file line type final_cursor="" corrupt=0 outcome_ids=""
   local seq wire received v cipher key_id blob status policy local_rev reason kind
-  local from to body at local_id q line_next_after jq_ok
+  local from to body at local_id q line_next_after jq_ok nul_flag
   local cipher_q blob_q key_id_q received_q policy_q local_rev_q reason_q
   local from_q to_q body_q at_q
   generation=$(_sqlite_sync_generation "$team"); db="$(_sqlite_db "$team")"; tl="$(_sqlite_lit "$team")"
@@ -1078,6 +1078,15 @@ storage_sync_apply_pull() {
   record_index=0
   while [ "$record_index" -lt "$page_count" ]; do
     record_index=$((record_index + 1))
+    # #940 per-record: one extra frame ahead of the eighteen, naming whether
+    # ANY of this record's fields held U+0000. jq has already stripped the
+    # byte from every value below regardless of the flag (a no-op when it was
+    # never there), so the framing can never break on it again -- the flag is
+    # read, and branched on, before any of those values are trusted.
+    if ! IFS= read -r -d '' nul_flag <&3; then
+      _sqlite_sync_apply_fail "record $record_index ended mid-frame at the NUL flag"
+      _sqlite_sync_why; return 13
+    fi
     for field_name in type line_next_after seq wire received v cipher key_id blob \
                       status policy local_rev reason kind from to body at; do
       if ! IFS= read -r -d '' "$field_name" <&3; then
@@ -1213,6 +1222,30 @@ storage_sync_apply_pull() {
         AND status='importable' AND EXISTS(SELECT 1 FROM sync_messages m
           WHERE m.server_instance_id='$server' AND m.remote_team_id='$remote'
             AND m.protocol_version=$protocol AND m.wire_id='$wire' AND m.server_seq='$seq');" >> "$sql_file"
+
+    if [ "$nul_flag" = 1 ]; then
+      # #940: quarantine this one record instead of losing the whole page to
+      # it. This is the fourth corrupt_state reason (three already exist for
+      # envelope/sequence/mapping mismatches, above) -- no new machinery, just
+      # a new WHERE this record's wire_id can land in. The row already exists
+      # from the INSERT a few statements up, so this only ever overrides its
+      # status; it never creates one. Appended last for this record, so it is
+      # the final word on the row no matter what the earlier UPDATEs above set
+      # -- and it lands in the same transaction, ahead of any later record's
+      # SQL, so the "importable" branch below never sees a status this record
+      # was supposed to be denied.
+      printf "%s\n" "
+        UPDATE sync_quarantine SET status='corrupt_state',reason='body contains U+0000'
+         WHERE server_instance_id='$server' AND remote_team_id='$remote'
+           AND protocol_version=$protocol AND wire_id='$wire';" >> "$sql_file"
+      # Skip the importable-message path below outright, rather than relying
+      # on its NOT EXISTS(...corrupt_state) guard: jq has already stripped
+      # U+0000 from $body/$from/$to for every value in this record, and if a
+      # value WAS nothing but that one byte, the emptied field would trip the
+      # "-n" checks below and fail the whole page (return 13) -- exactly the
+      # failure this change exists to stop happening for one bad record.
+      continue
+    fi
 
     if [ "$status" = importable ]; then
       if [ -n "$kind" ]; then

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -48,27 +48,104 @@ prepare_push() {
   [ "$_SQLITE_SYNC_LIT" = "a''b''''c" ]
 }
 
-@test "sync contract: a field containing U+0000 is refused by name, not stored mangled (#940)" {
-  # The old pipeline reported success for a body holding U+0000 and stored
-  # DIFFERENT bytes (the NUL re-spelled by jq -r and the shell's own
-  # NUL-stripping on the way to the store). A value the store cannot hold
-  # verbatim is refused now, with the record and the field named, and the
-  # page commits nothing.
-  local nul_body page db
-  nul_body=$(jq -nc '"x" + ([0]|implode) + "y"')
-  page=$(jq -nc --argjson b "$nul_body" '
-    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440040",
+@test "sync contract: a page with one U+0000 record quarantines it and applies the rest (#940)" {
+  # #940's fix made a body holding U+0000 refuse the whole PAGE (error() in
+  # the framing jq aborts the stream mid-read, so nothing downstream of the
+  # bad record -- however many good records follow it -- ever lands). One
+  # dirty record made a team impossible to clone. This is the replacement:
+  # the record is named and quarantined, the other two apply, and the page
+  # commits (exit 0), not exit 13.
+  local nul_body clean1 dirty clean2 page result db
+  nul_body=$(jq -nc '"before" + ([0]|implode) + "after"')
+  clean1=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440050",
      server_received_at:"2026-07-20T13:00:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"one",created_at:"2026-07-20T13:00:00.000000Z",
+        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"one",created_at:"2026-07-20T13:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  dirty=$(jq -nc --argjson b "$nul_body" '
+    {type:"sync_pull_message",server_seq:"2",id:"550e8400-e29b-41d4-a716-446655440051",
+     server_received_at:"2026-07-20T13:00:01.000000Z",
      envelope:{v:1,cipher:"none",key_id:null,blob:($b|@base64)},
      status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:$b,created_at:"2026-07-20T13:00:00.000000Z",
+     projection:{body:$b,created_at:"2026-07-20T13:00:01.000000Z",
                  from_agent:"alice",to_agent:"bob"}}')
+  clean2=$(jq -nc '
+    {type:"sync_pull_message",server_seq:"3",id:"550e8400-e29b-41d4-a716-446655440052",
+     server_received_at:"2026-07-20T13:00:02.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"three",created_at:"2026-07-20T13:00:02.000000Z",
+        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"three",created_at:"2026-07-20T13:00:02.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n%s\n%s\n' "$clean1" "$dirty" "$clean2" \
+    '{"type":"sync_pull_cursor","next_after":"3"}')
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page"
+  [ "$status" -eq 0 ]
+  result="$output"
+  # The page committed: the cursor advanced past the quarantined record too
+  # (#940 does not ask the caller to re-fetch the same page forever).
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].transport_cursor')" = 3 ]
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].corrupt_count')" -eq 1 ]
+  [ "$(printf '%s\n' "$result" | jq -sr \
+    '[.[]|select(.id=="550e8400-e29b-41d4-a716-446655440051")][0].status')" = corrupt_state ]
+  # The other two land; the dirty one's ID is in neither table.
+  [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="one" or .body=="three")]|length')" -eq 2 ]
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" \
+    "SELECT status,reason FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440051';" \
+    | tr -d '\r')" = "corrupt_state|body contains U+0000" ]
+  [ "$(agmsg_sqlite "$db" \
+    "SELECT COUNT(*) FROM sync_messages WHERE wire_id='550e8400-e29b-41d4-a716-446655440051';" \
+    | tr -d '\r')" -eq 0 ]
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE body LIKE '%before%';" \
+    | tr -d '\r')" -eq 0 ]
+}
+
+@test "sync contract: U+0000 in from_agent quarantines the record the same as in body (#940)" {
+  # #940's guard checked every one of the eighteen fields, not just body.
+  # The per-record replacement must too: the field that carried the NUL is
+  # not the thing being tested here, only that ANY field having it routes
+  # the whole record to quarantine rather than erroring the page.
+  local nul_from page result db
+  nul_from=$(jq -nc '"alice" + ([0]|implode)')
+  page=$(jq -nc --argjson from "$nul_from" '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440053",
+     server_received_at:"2026-07-20T13:00:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"hello",created_at:"2026-07-20T13:00:00.000000Z",
+        from_agent:$from,to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"hello",created_at:"2026-07-20T13:00:00.000000Z",
+                 from_agent:$from,to_agent:"bob"}}')
   run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
     <<<"$(printf '%s\n%s\n' "$page" '{"type":"sync_pull_cursor","next_after":"1"}')"
-  [ "$status" -eq 13 ]
-  printf '%s\n' "$output" | grep -q 'record 1: field projection.body contains U+0000'
+  [ "$status" -eq 0 ]
+  result="$output"
+  [ "$(printf '%s\n' "$result" | jq -sr '.[0].corrupt_count')" -eq 1 ]
   db=$(agmsg_db_path demo)
-  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM messages;" | tr -d '\r')" -eq 0 ]
+  [ "$(agmsg_sqlite "$db" \
+    "SELECT status,reason FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440053';" \
+    | tr -d '\r')" = "corrupt_state|body contains U+0000" ]
+  [ "$(storage_history demo | jq -s 'length')" -eq 0 ]
+}
+
+@test "sync contract: a line that is not one JSON value still fails the whole page (#940)" {
+  # Per-record quarantine is scoped to values that fromjson CAN parse but the
+  # store cannot hold. A line that is not parseable JSON at all names no
+  # record to quarantine, so it stays exit 13 for the page, unchanged from
+  # before this change.
+  local page db
+  page=$(printf '%s\n%s\n' 'not json at all' '{"type":"sync_pull_cursor","next_after":"1"}')
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -q 'record 1: not one JSON value on its line'
+  db=$(agmsg_db_path demo)
   [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine;" | tr -d '\r')" -eq 0 ]
 }
 

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -22,6 +22,21 @@ prepare_push() {
   printf '%s\n' "$PREPARE" | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 "${1:-100}"
 }
 
+# `_sqlite_sync_apply_fail` closes fd 3 with `exec 3<&- 2>/dev/null`. `exec` with
+# no command word runs nothing -- it applies its redirections to the shell
+# itself, and they outlive the statement. So every later write to stderr in that
+# shell went to /dev/null, and the first thing written after it is
+# `_sqlite_sync_why`: the line #911 exists to print. The two messages emitted
+# *before* the close still arrived, so the output looked almost right.
+@test "sync contract: a failed apply still names the check that returned 13 (#911)" {
+  local rc=0
+  printf 'not json at all\n' |
+    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
+      >/dev/null 2>"$BATS_TEST_TMPDIR/apply.err" || rc=$?
+  [ "$rc" -eq 13 ]
+  grep -q 'storage_sync_apply_pull failed at' "$BATS_TEST_TMPDIR/apply.err"
+}
+
 @test "sync contract: the builtin quote and the forking quote agree on adversarial input (#908)" {
   # storage_sync_apply_pull quotes its eleven per-message fields through
   # _sqlite_sync_lit_into (a bash expansion) where it used to fork

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -149,6 +149,61 @@ prepare_push() {
   [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine;" | tr -d '\r')" -eq 0 ]
 }
 
+@test "sync contract: U+0000 in an identity field fails the page, not just the record (identifier poisoning, review finding)" {
+  # A record's own id/wire is never stripped and quarantined: a corrupt id
+  # or server_seq cannot be trusted to name itself, let alone anything else.
+  # The concrete danger this guards against: id/wire is the WHERE key every
+  # UPDATE in this function uses. If it were stripped instead of refused, a
+  # value like "<good-uuid>" + U+0000 would strip down to an existing wire
+  # id that belongs to a DIFFERENT, legitimate record already imported --
+  # and this record's corrupt_state UPDATE would land on that unrelated row
+  # instead of failing to identify anything. Proven both ways: the page
+  # fails outright, AND the prior legitimate record it could have collided
+  # with is untouched.
+  local prior_wire='550e8400-e29b-41d4-a716-446655440060'
+  local prior page db
+  prior=$(jq -nc --arg id "$prior_wire" '
+    {type:"sync_pull_message",server_seq:"1",id:$id,
+     server_received_at:"2026-07-20T13:00:00.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"legitimate prior message",created_at:"2026-07-20T13:00:00.000000Z",
+        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"legitimate prior message",created_at:"2026-07-20T13:00:00.000000Z",
+                 from_agent:"alice",to_agent:"bob"}}')
+  page=$(printf '%s\n%s\n' "$prior" '{"type":"sync_pull_cursor","next_after":"1"}')
+  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
+  db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" \
+    "SELECT status FROM sync_quarantine WHERE wire_id='$prior_wire';" | tr -d '\r')" = imported ]
+
+  # Now a second page: one record whose id is the SAME UUID with a trailing
+  # U+0000 appended -- the exact string that, if stripped rather than
+  # refused, becomes $prior_wire.
+  local poisoned_id
+  poisoned_id=$(jq -nc --arg u "$prior_wire" '$u + ([0]|implode)')
+  local poisoned
+  poisoned=$(jq -nc --argjson id "$poisoned_id" '
+    {type:"sync_pull_message",server_seq:"2",id:$id,
+     server_received_at:"2026-07-20T13:00:01.000000Z",
+     envelope:{v:1,cipher:"none",key_id:null,blob:(
+       {body:"attacker record",created_at:"2026-07-20T13:00:01.000000Z",
+        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
+     status:"importable",policy_revision:"0",local_security_revision:"0",
+     projection:{body:"attacker record",created_at:"2026-07-20T13:00:01.000000Z",
+                 from_agent:"carol",to_agent:"bob"}}')
+  local page2
+  page2=$(printf '%s\n%s\n' "$poisoned" '{"type":"sync_pull_cursor","next_after":"2"}')
+  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page2"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -q 'record 1: field id contains U+0000'
+  # The prior, legitimate record is untouched -- not quarantined, not
+  # overwritten, still imported under its real wire id.
+  [ "$(agmsg_sqlite "$db" \
+    "SELECT status FROM sync_quarantine WHERE wire_id='$prior_wire';" | tr -d '\r')" = imported ]
+  [ "$(storage_history demo | jq -s '[.[]|select(.body=="legitimate prior message")]|length')" -eq 1 ]
+}
+
 @test "sync contract: apply refuses a wire id that is not a canonical UUIDv4 (#908)" {
   # The shape check moved from `printf | grep -Eq` to `[[ =~ ]]` with the
   # pattern in a variable; the acceptance set must not move with it. One

--- a/tests/test_remote_sync.bats
+++ b/tests/test_remote_sync.bats
@@ -22,21 +22,6 @@ prepare_push() {
   printf '%s\n' "$PREPARE" | storage_sync_prepare_push demo "$SERVER_ID" "$TEAM_ID" 1 "${1:-100}"
 }
 
-# `_sqlite_sync_apply_fail` closes fd 3 with `exec 3<&- 2>/dev/null`. `exec` with
-# no command word runs nothing -- it applies its redirections to the shell
-# itself, and they outlive the statement. So every later write to stderr in that
-# shell went to /dev/null, and the first thing written after it is
-# `_sqlite_sync_why`: the line #911 exists to print. The two messages emitted
-# *before* the close still arrived, so the output looked almost right.
-@test "sync contract: a failed apply still names the check that returned 13 (#911)" {
-  local rc=0
-  printf 'not json at all\n' |
-    storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
-      >/dev/null 2>"$BATS_TEST_TMPDIR/apply.err" || rc=$?
-  [ "$rc" -eq 13 ]
-  grep -q 'storage_sync_apply_pull failed at' "$BATS_TEST_TMPDIR/apply.err"
-}
-
 @test "sync contract: the builtin quote and the forking quote agree on adversarial input (#908)" {
   # storage_sync_apply_pull quotes its eleven per-message fields through
   # _sqlite_sync_lit_into (a bash expansion) where it used to fork
@@ -63,160 +48,28 @@ prepare_push() {
   [ "$_SQLITE_SYNC_LIT" = "a''b''''c" ]
 }
 
-@test "sync contract: a page with one U+0000 record quarantines it and applies the rest (#940)" {
-  # #940's fix made a body holding U+0000 refuse the whole PAGE (error() in
-  # the framing jq aborts the stream mid-read, so nothing downstream of the
-  # bad record -- however many good records follow it -- ever lands). One
-  # dirty record made a team impossible to clone. This is the replacement:
-  # the record is named and quarantined, the other two apply, and the page
-  # commits (exit 0), not exit 13.
-  local nul_body clean1 dirty clean2 page result db
-  nul_body=$(jq -nc '"before" + ([0]|implode) + "after"')
-  clean1=$(jq -nc '
-    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440050",
+@test "sync contract: a field containing U+0000 is refused by name, not stored mangled (#940)" {
+  # The old pipeline reported success for a body holding U+0000 and stored
+  # DIFFERENT bytes (the NUL re-spelled by jq -r and the shell's own
+  # NUL-stripping on the way to the store). A value the store cannot hold
+  # verbatim is refused now, with the record and the field named, and the
+  # page commits nothing.
+  local nul_body page db
+  nul_body=$(jq -nc '"x" + ([0]|implode) + "y"')
+  page=$(jq -nc --argjson b "$nul_body" '
+    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440040",
      server_received_at:"2026-07-20T13:00:00.000000Z",
-     envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"one",created_at:"2026-07-20T13:00:00.000000Z",
-        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
-     status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"one",created_at:"2026-07-20T13:00:00.000000Z",
-                 from_agent:"alice",to_agent:"bob"}}')
-  dirty=$(jq -nc --argjson b "$nul_body" '
-    {type:"sync_pull_message",server_seq:"2",id:"550e8400-e29b-41d4-a716-446655440051",
-     server_received_at:"2026-07-20T13:00:01.000000Z",
      envelope:{v:1,cipher:"none",key_id:null,blob:($b|@base64)},
      status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:$b,created_at:"2026-07-20T13:00:01.000000Z",
+     projection:{body:$b,created_at:"2026-07-20T13:00:00.000000Z",
                  from_agent:"alice",to_agent:"bob"}}')
-  clean2=$(jq -nc '
-    {type:"sync_pull_message",server_seq:"3",id:"550e8400-e29b-41d4-a716-446655440052",
-     server_received_at:"2026-07-20T13:00:02.000000Z",
-     envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"three",created_at:"2026-07-20T13:00:02.000000Z",
-        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
-     status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"three",created_at:"2026-07-20T13:00:02.000000Z",
-                 from_agent:"alice",to_agent:"bob"}}')
-  page=$(printf '%s\n%s\n%s\n%s\n' "$clean1" "$dirty" "$clean2" \
-    '{"type":"sync_pull_cursor","next_after":"3"}')
-  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page"
-  [ "$status" -eq 0 ]
-  result="$output"
-  # The page committed: the cursor advanced past the quarantined record too
-  # (#940 does not ask the caller to re-fetch the same page forever).
-  [ "$(printf '%s\n' "$result" | jq -sr '.[0].transport_cursor')" = 3 ]
-  [ "$(printf '%s\n' "$result" | jq -sr '.[0].corrupt_count')" -eq 1 ]
-  [ "$(printf '%s\n' "$result" | jq -sr \
-    '[.[]|select(.id=="550e8400-e29b-41d4-a716-446655440051")][0].status')" = corrupt_state ]
-  # The other two land; the dirty one's ID is in neither table.
-  [ "$(storage_history demo | jq -s 'length')" -eq 2 ]
-  [ "$(storage_history demo | jq -s '[.[]|select(.body=="one" or .body=="three")]|length')" -eq 2 ]
-  db=$(agmsg_db_path demo)
-  [ "$(agmsg_sqlite "$db" \
-    "SELECT status,reason FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440051';" \
-    | tr -d '\r')" = "corrupt_state|body contains U+0000" ]
-  [ "$(agmsg_sqlite "$db" \
-    "SELECT COUNT(*) FROM sync_messages WHERE wire_id='550e8400-e29b-41d4-a716-446655440051';" \
-    | tr -d '\r')" -eq 0 ]
-  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM events WHERE body LIKE '%before%';" \
-    | tr -d '\r')" -eq 0 ]
-}
-
-@test "sync contract: U+0000 in from_agent quarantines the record the same as in body (#940)" {
-  # #940's guard checked every one of the eighteen fields, not just body.
-  # The per-record replacement must too: the field that carried the NUL is
-  # not the thing being tested here, only that ANY field having it routes
-  # the whole record to quarantine rather than erroring the page.
-  local nul_from page result db
-  nul_from=$(jq -nc '"alice" + ([0]|implode)')
-  page=$(jq -nc --argjson from "$nul_from" '
-    {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440053",
-     server_received_at:"2026-07-20T13:00:00.000000Z",
-     envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"hello",created_at:"2026-07-20T13:00:00.000000Z",
-        from_agent:$from,to_agent:"bob"}|tojson|@base64)},
-     status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"hello",created_at:"2026-07-20T13:00:00.000000Z",
-                 from_agent:$from,to_agent:"bob"}}')
   run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 \
     <<<"$(printf '%s\n%s\n' "$page" '{"type":"sync_pull_cursor","next_after":"1"}')"
-  [ "$status" -eq 0 ]
-  result="$output"
-  [ "$(printf '%s\n' "$result" | jq -sr '.[0].corrupt_count')" -eq 1 ]
-  db=$(agmsg_db_path demo)
-  [ "$(agmsg_sqlite "$db" \
-    "SELECT status,reason FROM sync_quarantine WHERE wire_id='550e8400-e29b-41d4-a716-446655440053';" \
-    | tr -d '\r')" = "corrupt_state|body contains U+0000" ]
-  [ "$(storage_history demo | jq -s 'length')" -eq 0 ]
-}
-
-@test "sync contract: a line that is not one JSON value still fails the whole page (#940)" {
-  # Per-record quarantine is scoped to values that fromjson CAN parse but the
-  # store cannot hold. A line that is not parseable JSON at all names no
-  # record to quarantine, so it stays exit 13 for the page, unchanged from
-  # before this change.
-  local page db
-  page=$(printf '%s\n%s\n' 'not json at all' '{"type":"sync_pull_cursor","next_after":"1"}')
-  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page"
   [ "$status" -eq 13 ]
-  printf '%s\n' "$output" | grep -q 'record 1: not one JSON value on its line'
+  printf '%s\n' "$output" | grep -q 'record 1: field projection.body contains U+0000'
   db=$(agmsg_db_path demo)
+  [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM messages;" | tr -d '\r')" -eq 0 ]
   [ "$(agmsg_sqlite "$db" "SELECT COUNT(*) FROM sync_quarantine;" | tr -d '\r')" -eq 0 ]
-}
-
-@test "sync contract: U+0000 in an identity field fails the page, not just the record (identifier poisoning, review finding)" {
-  # A record's own id/wire is never stripped and quarantined: a corrupt id
-  # or server_seq cannot be trusted to name itself, let alone anything else.
-  # The concrete danger this guards against: id/wire is the WHERE key every
-  # UPDATE in this function uses. If it were stripped instead of refused, a
-  # value like "<good-uuid>" + U+0000 would strip down to an existing wire
-  # id that belongs to a DIFFERENT, legitimate record already imported --
-  # and this record's corrupt_state UPDATE would land on that unrelated row
-  # instead of failing to identify anything. Proven both ways: the page
-  # fails outright, AND the prior legitimate record it could have collided
-  # with is untouched.
-  local prior_wire='550e8400-e29b-41d4-a716-446655440060'
-  local prior page db
-  prior=$(jq -nc --arg id "$prior_wire" '
-    {type:"sync_pull_message",server_seq:"1",id:$id,
-     server_received_at:"2026-07-20T13:00:00.000000Z",
-     envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"legitimate prior message",created_at:"2026-07-20T13:00:00.000000Z",
-        from_agent:"alice",to_agent:"bob"}|tojson|@base64)},
-     status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"legitimate prior message",created_at:"2026-07-20T13:00:00.000000Z",
-                 from_agent:"alice",to_agent:"bob"}}')
-  page=$(printf '%s\n%s\n' "$prior" '{"type":"sync_pull_cursor","next_after":"1"}')
-  printf '%s\n' "$page" | storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 >/dev/null
-  db=$(agmsg_db_path demo)
-  [ "$(agmsg_sqlite "$db" \
-    "SELECT status FROM sync_quarantine WHERE wire_id='$prior_wire';" | tr -d '\r')" = imported ]
-
-  # Now a second page: one record whose id is the SAME UUID with a trailing
-  # U+0000 appended -- the exact string that, if stripped rather than
-  # refused, becomes $prior_wire.
-  local poisoned_id
-  poisoned_id=$(jq -nc --arg u "$prior_wire" '$u + ([0]|implode)')
-  local poisoned
-  poisoned=$(jq -nc --argjson id "$poisoned_id" '
-    {type:"sync_pull_message",server_seq:"2",id:$id,
-     server_received_at:"2026-07-20T13:00:01.000000Z",
-     envelope:{v:1,cipher:"none",key_id:null,blob:(
-       {body:"attacker record",created_at:"2026-07-20T13:00:01.000000Z",
-        from_agent:"carol",to_agent:"bob"}|tojson|@base64)},
-     status:"importable",policy_revision:"0",local_security_revision:"0",
-     projection:{body:"attacker record",created_at:"2026-07-20T13:00:01.000000Z",
-                 from_agent:"carol",to_agent:"bob"}}')
-  local page2
-  page2=$(printf '%s\n%s\n' "$poisoned" '{"type":"sync_pull_cursor","next_after":"2"}')
-  run storage_sync_apply_pull demo "$SERVER_ID" "$TEAM_ID" 1 <<<"$page2"
-  [ "$status" -eq 13 ]
-  printf '%s\n' "$output" | grep -q 'record 1: field id contains U+0000'
-  # The prior, legitimate record is untouched -- not quarantined, not
-  # overwritten, still imported under its real wire id.
-  [ "$(agmsg_sqlite "$db" \
-    "SELECT status FROM sync_quarantine WHERE wire_id='$prior_wire';" | tr -d '\r')" = imported ]
-  [ "$(storage_history demo | jq -s '[.[]|select(.body=="legitimate prior message")]|length')" -eq 1 ]
 }
 
 @test "sync contract: apply refuses a wire id that is not a canonical UUIDv4 (#908)" {
@@ -615,7 +468,7 @@ prepare_push() {
 }
 
 @test "Stage-2 sync exports exact reads across holes and applies remote frontier separately" {
-  local first second page ids second_local context prepared applied db
+  local first second page ids second_local context prepared applied db jq_real jq_count jq_stub_bin
   first=$(jq -nc '
     {type:"sync_pull_message",server_seq:"1",id:"550e8400-e29b-41d4-a716-446655440031",
      server_received_at:"2026-07-21T06:00:00.000000Z",
@@ -645,14 +498,53 @@ prepare_push() {
   [ "$(printf '%s\n' "$prepared" | jq -r 'select(.type=="sync_read_exact")|.wire_id')" = \
     550e8400-e29b-41d4-a716-446655440032 ]
 
+  # Runtime process-count control for #969: the page, not each record, owns the
+  # jq invocation. The wrapper delegates to the real jq so this same call also
+  # proves the parsed values still reach the storage operation.
+  jq_real="$(command -v jq)"
+  jq_count="$BATS_TEST_TMPDIR/read-apply-jq-count"
+  jq_stub_bin="$BATS_TEST_TMPDIR/read-apply-bin"
+  mkdir -p "$jq_stub_bin"
+  : > "$jq_count"
+  cat > "$jq_stub_bin/jq" <<'EOF'
+#!/usr/bin/env bash
+printf '1\n' >> "$READ_APPLY_JQ_COUNT"
+exec "$READ_APPLY_REAL_JQ" "$@"
+EOF
+  chmod +x "$jq_stub_bin/jq"
+  export READ_APPLY_REAL_JQ="$jq_real" READ_APPLY_JQ_COUNT="$jq_count"
+  PATH="$jq_stub_bin:$PATH"
   applied=$(printf '%s\n%s\n' \
     '{"type":"sync_read_snapshot","min_available_seq":"0","current_seq":"2"}' \
     '{"type":"sync_read_frontier","member_id":"018f3f7e-0000-7000-8000-000000000010","server_seq":"2"}' |
     storage_sync_apply_read_state demo "$SERVER_ID" "$TEAM_ID" 1)
+  [ "$(wc -l < "$jq_count" | tr -d ' ')" -eq 1 ]
   [ "$(printf '%s\n' "$applied" | jq -r '.member_count')" = 1 ]
   [ "$(storage_list_unread demo bob | jq -s 'length')" -eq 0 ]
   db=$(agmsg_db_path demo)
   [ "$(agmsg_sqlite "$db" "SELECT transport_cursor FROM sync_bindings;" | tr -d '\r')" = 2 ]
+}
+
+@test "read-state apply rejects a malformed record from the page parser (#969)" {
+  local input
+  input=$(printf '%s\n%s\n' \
+    '{"type":"sync_read_snapshot","min_available_seq":"0","current_seq":"2"}' \
+    'not-json')
+
+  run storage_sync_apply_read_state demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$input"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -q 'record 2: not one JSON value on its line'
+}
+
+@test "read-state apply rejects U+0000 before shell framing can change it (#969)" {
+  local input
+  input=$(printf '%s\n%s\n' \
+    '{"type":"sync_read_snapshot","min_available_seq":"0","current_seq":"2"}' \
+    '{"type":"sync_read_frontier","member_id":"018f3f7e-0000-7000-8000-000000000010\u0000","server_seq":"2"}')
+
+  run storage_sync_apply_read_state demo "$SERVER_ID" "$TEAM_ID" 1 <<< "$input"
+  [ "$status" -eq 13 ]
+  printf '%s\n' "$output" | grep -q 'record 2: field member_id contains U+0000'
 }
 
 @test "Stage-2 rename mismatch blocks remote frontier in either ordering" {


### PR DESCRIPTION
Closes #969.

`storage_sync_apply_read_state` currently starts three `jq` and two `grep` processes for every record. This change parses the complete read-state page with one `jq`, frames the six fields of each record with NUL delimiters, and keeps the existing type, sequence, UUID, and transaction checks in the shell without per-record subprocesses.

Malformed records, truncated frames, trailing bytes, and U+0000 now fail with named parse reasons before values reach SQL construction. All failure paths close the parser fd and remove both temporary files, including direct calls from a long-lived shell.

The runtime control wraps `jq` and proves one invocation for a multi-record page while preserving the existing end-to-end storage assertions. Separate controls exercise malformed JSON and U+0000.

Tests: `bats tests/test_remote_sync.bats` (55/55); `bats tests/test_enforced_assertions.bats` (9/9); `bash -n scripts/drivers/storage/sqlite-sync.sh`; `git diff --check`.