### PR TITLE
Decide hook ownership by install path, not a substring of the skill name (#1038)

### DIFF
--- a/scripts/delivery.sh
+++ b/scripts/delivery.sh
@@ -58,7 +58,7 @@ RUN_DIR="$SKILL_DIR/run"
 # primitives use it, so source storage first.
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/storage.sh"
-# JSON/SQLite hook-file primitives (sourced after SKILL_NAME is set above —
+# JSON/SQLite hook-file primitives (sourced after SKILL_DIR is set above —
 # strip/add reference it to detect agmsg-owned entries).
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/lib/hooks-json.sh"
@@ -311,17 +311,21 @@ agmsg_delivery_status_default() {
     valid=$(agmsg_sqlite_mem "SELECT json_valid(readfile('$sql_hf'));" 2>/dev/null || echo "")
     if [ "$valid" = "1" ]; then
       hf_readable=1
+      # #1038: ownership by the absolute install path, not a substring of the
+      # bare skill name — see strip_agmsg_event_file (hooks-json.sh) for why.
+      local skill_dir_sql
+      skill_dir_sql=$(printf '%s' "$SKILL_DIR" | sed "s/'/''/g")
       has_ss=$(agmsg_sqlite_mem "
         SELECT EXISTS(
           SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.SessionStart')) AS s,
             json_each(json_extract(s.value, '\$.hooks')) AS h
-          WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+          WHERE instr(json_extract(h.value, '\$.command'), '$skill_dir_sql') > 0
         );" 2>/dev/null || echo 0)
       has_st=$(agmsg_sqlite_mem "
         SELECT EXISTS(
           SELECT 1 FROM json_each(json_extract(readfile('$sql_hf'), '\$.hooks.Stop')) AS s,
             json_each(json_extract(s.value, '\$.hooks')) AS h
-          WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+          WHERE instr(json_extract(h.value, '\$.command'), '$skill_dir_sql') > 0
         );" 2>/dev/null || echo 0)
     fi
   fi

--- a/scripts/lib/hooks-json.sh
+++ b/scripts/lib/hooks-json.sh
@@ -10,7 +10,7 @@
 # #162 byte-count validation, #134 JSON escaping) — can be read and tested on
 # its own.
 #
-# Sourced by delivery.sh AFTER it defines SKILL_NAME (used to detect
+# Sourced by delivery.sh AFTER it defines SKILL_DIR (used to detect
 # agmsg-owned entries); the existing lib convention is for sourced modules to
 # reference caller-set globals rather than re-resolve them.
 
@@ -40,6 +40,16 @@ strip_agmsg_event_file() {
   local tmp tmp_sql
   tmp=$(mktemp "${TMPDIR:-/tmp}/agmsg.XXXXXX")
   tmp_sql=$(agmsg_sql_readfile_path "$tmp")
+  # Ownership is decided against the absolute install directory, not the bare
+  # skill name (#1038): a project's OWN hook whose command happens to contain
+  # the substring "agmsg" -- a natural name for a hook that cooperates with
+  # this tool -- used to match `instr(command, '$SKILL_NAME')` and get
+  # silently stripped alongside agmsg's real entries. $SKILL_DIR is this
+  # install's own absolute path; every command agmsg ever writes invokes a
+  # script under it, and nothing legitimately outside agmsg's install would
+  # ever contain that exact path as a substring.
+  local skill_dir_sql
+  skill_dir_sql=$(printf '%s' "$SKILL_DIR" | sed "s/'/''/g")
   # Write the result with writefile() rather than redirecting sqlite3's CLI
   # output. On strict sqlite3 builds (>= 3.50, shipped on Windows) the CLI
   # renders control bytes — e.g. a CR that rode in on a CRLF settings file —
@@ -62,7 +72,7 @@ strip_agmsg_event_file() {
       WHEN (SELECT count(*) FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
             WHERE NOT EXISTS (
               SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
-              WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+              WHERE instr(json_extract(h.value, '\$.command'), '$skill_dir_sql') > 0
             )) = 0 THEN
         json_remove(src.j, '\$.hooks.$event')
       ELSE
@@ -71,7 +81,7 @@ strip_agmsg_event_file() {
            FROM json_each(json_extract(src.j, '\$.hooks.$event')) AS s
            WHERE NOT EXISTS (
              SELECT 1 FROM json_each(json_extract(s.value, '\$.hooks')) AS h
-             WHERE instr(json_extract(h.value, '\$.command'), '$SKILL_NAME') > 0
+             WHERE instr(json_extract(h.value, '\$.command'), '$skill_dir_sql') > 0
            ))
         )
     END, '') AS blob FROM src)

--- a/tests/test_delivery.bats
+++ b/tests/test_delivery.bats
@@ -128,6 +128,35 @@ settings_file() {
   [ "$p" = "Bash" ]
 }
 
+@test "delivery set: does not strip a project's OWN hook merely because its command contains the skill name (#1038)" {
+  # A project's own SessionStart hook, named after the tool it cooperates
+  # with -- a natural convention, and exactly what used to trigger this:
+  # ownership was decided by instr(command, SKILL_NAME), a substring match
+  # on the bare skill name, not by the exact install path agmsg actually
+  # writes. Derived from $SCRIPTS, not hardcoded as "agmsg": the test
+  # harness copies the skill into a mktemp -d directory (test_helper.bash),
+  # so the real SKILL_NAME a running delivery.sh sees here is that
+  # directory's own basename, never the literal word "agmsg" -- a fixture
+  # hardcoding "agmsg" would pass whether or not the fix was in place, and
+  # say nothing.
+  local skill_name
+  skill_name="$(basename "$(dirname "$SCRIPTS")")"
+  mkdir -p "$TEST_PROJECT/.claude"
+  printf '%s' '{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"'"$TEST_PROJECT"'/scripts/'"$skill_name"'-my-wrapper.sh"}]}]}}' \
+    > "$(settings_file)"
+
+  run bash "$SCRIPTS/delivery.sh" set monitor claude-code "$TEST_PROJECT"
+  [ "$status" -eq 0 ]
+
+  # The project's own hook survived the strip...
+  grep -q "${skill_name}-my-wrapper.sh" "$(settings_file)"
+  # ...and agmsg's own entry landed alongside it, not instead of it.
+  has_session_start "$(settings_file)"
+  local n
+  n=$(sqlite_mem "SELECT count(*) FROM json_each(json_extract(readfile('$(rf "$(settings_file)")'), '\$.hooks.SessionStart'));")
+  [ "$n" -eq 2 ]
+}
+
 @test "delivery set monitor: round-trips multibyte (UTF-8) settings without a short-write reject" {
   # The writefile() guard compares bytes written to the content's BYTE length
   # (CAST AS BLOB). A character-length comparison would mismatch on multibyte


### PR DESCRIPTION
Fixes #1038.

`strip_agmsg_event_file` (and the two `delivery status` queries mirroring it) decided whether a hook entry belonged to agmsg with `instr(command, SKILL_NAME)` — a substring match against the bare skill name (e.g. `agmsg`). A project's own hook, named after the tool it cooperates with (a natural convention — e.g. `scripts/agmsg-my-wrapper.sh`), matched the same substring and was silently stripped alongside agmsg's real entries on the next `delivery.sh set <mode>`, with nothing reporting that an entry had been removed.

Same family as #1169, fixed elsewhere in this codebase already: ownership decided by a substring match, so a coincidental match elsewhere quietly takes something that was never agmsg's.

## Fix

Match against `$SKILL_DIR` instead — this install's own absolute path, already known to every caller (`delivery.sh` sets it before sourcing `hooks-json.sh`), escaped once per call for the SQL literal. Every command agmsg ever writes invokes a script under it; nothing legitimately outside agmsg's install would ever contain that exact path as a substring, so this narrows the match to the exact thing the issue's own suggested fix asked for, without adding a new marker or touching the write side.

Three call sites shared the same root cause and are all fixed the same way: `strip_agmsg_event_file` (the destructive one the issue reports), plus the two read-only `has_ss`/`has_st` queries in `agmsg_delivery_status_default` (same bug, lower severity — a wrong status report rather than data loss, but the same substring hazard).

## Verification

- `tests/test_delivery.bats` gains the failing-side control: a project's own hook whose command contains the (test-time) skill name now survives `delivery set`, verified red by reverting the fix and re-running. The fixture derives the skill name from `$SCRIPTS` rather than hardcoding `"agmsg"` — the test harness copies the skill into a `mktemp -d` directory, so a hardcoded literal would have passed whether or not the fix was in place, and said nothing.
- Full file re-run after restoring the fix: `test_delivery.bats` 199/199.
- `check-enforced-assertions.sh`: 626/626, baseline unchanged.
- `check-unguarded-env-reads.sh`: 88/89 (one fewer than baseline — the two raw `$SKILL_NAME` reads this removes are no longer counted, replaced by a properly-assigned local).
- `bash -n` on both changed files: OK.

Base: `integration/terminal-driver-v1` tip at branch time (`532a60f4`).
