### PR TITLE
feat(send): accept --body-file/--body like poke, and refuse a flag-shaped body (#1101)

### DIFF
--- a/scripts/send.sh
+++ b/scripts/send.sh
@@ -1,16 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: send.sh <team> <from> <to> <message> [--force]
+# Usage:
+#   send.sh <team> <from> <to> <message> [--force]              # body as ONE quoted arg
+#   send.sh <team> <from> <to> --body-file <path> [--force]     # body read from a file
+#   send.sh <team> <from> <to> --body - [--force]               # body read from stdin
+#
+# --body-file matches poke.sh, for the same reason (#507) AND to close #1101: a caller
+# who learned --body-file from poke used to have send take the literal string
+# "--body-file" as the message and exit zero (the flag has different meanings on the two
+# adjacent commands). A positional <message> also passes through the CALLER's shell first,
+# where a backtick or $( ) executes and its span silently vanishes; send bodies are longer
+# and likelier to contain them. So a message that is a bare unconsumed flag (starts with
+# --, and is not --body-file/--body) is now REFUSED rather than sent, and a mistyped flag
+# never lands as content. Trailing newlines are stripped from a file/stdin body, as in
+# poke (command-substitution semantics).
 
-TEAM="${1:?Usage: send.sh <team> <from> <to> <message> [--force]}"
+die() { echo "send.sh: $*" >&2; exit 1; }
+
+TEAM="${1:?Usage: send.sh <team> <from> <to> <message|--body-file PATH|--body -> [--force]}"
 FROM="${2:?Missing from agent}"
 TO="${3:?Missing to agent}"
-BODY="${4:?Missing message body}"
+shift 3
+
+# --force is historically the trailing flag AFTER the body; recognize it only as the
+# last argument, so a --body-file body whose text happens to be "--force" is unaffected.
 FORCE=0
-if [ "${5:-}" = "--force" ]; then
+if [ "$#" -gt 0 ] && [ "${!#}" = "--force" ]; then
   FORCE=1
+  set -- "${@:1:$#-1}"
 fi
+
+case "${1:-}" in
+  --body-file)
+    [ "$#" -eq 2 ] || die "--body-file takes exactly one path"
+    [ -r "${2:-}" ] || die "cannot read body file: ${2:-<missing>}"
+    BODY="$(cat -- "$2")"
+    ;;
+  --body)
+    { [ "$#" -eq 2 ] && [ "${2:-}" = "-" ]; } \
+      || die "--body accepts only '-' (read stdin); for a file use --body-file <path>"
+    BODY="$(cat)"
+    ;;
+  '')
+    die "Missing message body"
+    ;;
+  --*)
+    die "unrecognized option '${1}' — a message that starts with '-' must go through --body-file <path> or --body - (a bare flag is refused so a mistyped one is never sent as the message, #1101)"
+    ;;
+  *)
+    [ "$#" -eq 1 ] || die "got extra arguments — quote the message as ONE argument, or use --body-file <path>"
+    BODY="$1"
+    ;;
+esac
+[ -n "$BODY" ] || die "the message body is empty — nothing to send"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/storage.sh"

--- a/tests/test_messaging.bats
+++ b/tests/test_messaging.bats
@@ -61,6 +61,54 @@ teardown() {
   [ "$n" -eq 1 ]
 }
 
+# --- send.sh: --body-file / flag-shaped body (#1101) ---
+
+@test "send: --body-file delivers a body that begins with a hyphen, intact (#1101)" {
+  # The exact trap #1101 filed: a caller reaches for poke's flag on send, and the
+  # body here IS a flag string. It must arrive as content, not be consumed. Through
+  # the supported route (--body-file) the recipient receives it whole.
+  printf -- '--body-file is the literal message here' > "$TEST_SKILL_DIR/body.txt"
+  run bash "$SCRIPTS/send.sh" testteam alice bob --body-file "$TEST_SKILL_DIR/body.txt"
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--body-file is the literal message here"* ]]
+}
+
+@test "send: a bare --body-file with no path is refused, not sent (#1101)" {
+  run bash "$SCRIPTS/send.sh" testteam alice bob --body-file
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"takes exactly one path"* ]]
+  # Nothing was delivered: the refusal happens at parse, before any write.
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" == *"No new messages"* ]]
+}
+
+@test "send: a flag-shaped message is refused rather than sent as content (#1101)" {
+  # Before the fix, send took a leading-flag string as the body and exited zero, so a
+  # mistyped flag landed silently as a one-word message. It must be refused, and the
+  # recipient must receive nothing (not the string "--nope").
+  run bash "$SCRIPTS/send.sh" testteam alice bob --nope
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unrecognized option"* ]]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" == *"No new messages"* ]]
+}
+
+@test "send: --body-file rides alongside a trailing --force (#1101)" {
+  printf 'delivered from a file' > "$TEST_SKILL_DIR/b2.txt"
+  run bash "$SCRIPTS/send.sh" brandnewteam ghost nobody --body-file "$TEST_SKILL_DIR/b2.txt" --force
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Sent to nobody" ]]
+}
+
+@test "send: --body - reads the message from stdin (#1101)" {
+  run bash -c "printf 'from stdin, intact' | bash '$SCRIPTS/send.sh' testteam alice bob --body -"
+  [ "$status" -eq 0 ]
+  run bash "$SCRIPTS/inbox.sh" testteam bob
+  [[ "$output" == *"from stdin, intact"* ]]
+}
+
 # --- send.sh: team-name validation (#414) ---
 
 @test "send: rejects a team name with path traversal (../) and never consults a config outside teams/" {


### PR DESCRIPTION
## What

`send` now accepts `--body-file <path>` and `--body -` (stdin) with the same meaning they have on `poke`, and refuses a message that is a bare unconsumed flag.

## Why (the trap #1101 filed)

`poke` takes `--body-file`; `send` took its body as the 4th positional. A caller who learned the flag from `poke` reached for it on `send`, which delivered the literal string `--body-file` and exited zero — sender saw success, recipient saw one word. It happened twice in a row between two agents before anyone worked out why, because the failure gave no signal. The same flag meant different things on two adjacent commands.

## Fix

- **Consolidate toward `poke`**: `send <team> <from> <to> --body-file <path>` reads the body from a file; `--body -` reads stdin. Trailing newlines stripped, as in `poke` (the #507 shell-hostile-body reason applies at least as strongly to `send`, whose bodies are longer). The positional one-argument form stays.
- **`--force` unchanged**: recognized only as the trailing argument, so a `--body-file` body whose text is literally `--force` is unaffected.
- **Refuse a flag-shaped body**: a message beginning with `--` that is not `--body-file`/`--body` now errors, pointing the caller at `--body-file`, rather than being sent as content — a mistyped flag never lands as the message. A single leading `-` (prose like `-1`) is still a valid positional body; only double-dash flag shapes are refused.

## Not breaking existing callers

No existing caller passes a `--`-leading positional body to `send` (grep across `scripts/` and `tests/`; the only `--`-token used is `--force`). The positional path is otherwise unchanged.

## Tests (in `tests/test_messaging.bats`)

- a hyphen-leading body delivered whole through `--body-file` (the acceptance test);
- a bare `--body-file` with no path refused, nothing delivered;
- a flag-shaped body refused, recipient receives nothing (not the string `--nope`);
- `--body-file` alongside a trailing `--force`;
- `--body -` from stdin.

Full `tests/test_messaging.bats` green (32/32). CI-only surfaces (shellcheck runs #1068).